### PR TITLE
Removed the console logging of each change for the markdown plugin

### DIFF
--- a/src/plugins/markdown/withMarkdown.jsx
+++ b/src/plugins/markdown/withMarkdown.jsx
@@ -19,8 +19,6 @@ export default Editor =>
   class extends Component {
     handleMarkdownChange = (html) => {
       const { converters = [], gfm = true } = this.props
-
-      console.log(html)
       this.props.onChange(htmlToMarkdown(html, converters, gfm))
     }
 


### PR DESCRIPTION
While trying this out, I came across a console.log(..) in the markdown plugin.